### PR TITLE
Proxy to jeffseemann.test in local development

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,5 @@
 # override settings here during development, copy this file to .env.local
 # and change values appropriately.
 
-REACT_APP_DIRECTUS_PROTOCOL=http:
-REACT_APP_DIRECTUS_HOSTNAME=jeffwebsite.test
+HOST=jeffseemann.test
+REACT_APP_DIRECTUS_ENDPOINT=

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install
 If you are having difficulties logging in, look up a [Digital Ocean](https://www.digitalocean.com/community/tutorials/how-to-create-a-new-user-and-grant-permissions-in-mysql) tutorial! You'll use this database name later.
 ```sh
 mysql -u $USER -p
-create database jeffwebsite;
+create database jeffseemann;
 quit;
 ```
 
@@ -54,8 +54,8 @@ quit;
 Get an initial dump of Jeff's website to [import](https://s3.core.uconn.edu/minio/login).
 Download image assets and place in `jeffseemann.uconn.edu/cms/storage/`.
 ```sh
-gunzip jeffwebsiteDatabase.sql.gz
-mysql < jeffwebsiteDatabase.sql
+gunzip jeffseemannDatabase.sql.gz
+mysql < jeffseemannDatabase.sql
 ```
 
 ### Install required php packages:
@@ -66,15 +66,15 @@ sudo apt install php7.1-xml
 ```
 
 ### Set up Nginx
-Copy the `default` file from the [Directus respository](https://github.com/directus/directus-vagrant/tree/master/config/nginx) into the file `jeff-website.com`. See file path below.
+Copy the `default` file from the [Directus respository](https://github.com/directus/directus-vagrant/tree/master/config/nginx) into the file `jeffseemann`. See file path below.
 Optionally, you could create this file in `/etc/nginx/sites-available/` and create a symbolic link to `/etc/nginx/sites-enabled/`.
 Change the line `root /var/www/html;` to `root /home/$USER/jeffseemann.uconn.edu/cms`, where $USER is the name of your machine. Remove the line `include pagespeed.conf;` from the file.
-Change the line `server_name localhost;` to `server_name jeffwebsite.test;` since you'll probably be using localhost for something else.
+Change the line `server_name localhost;` to `server_name jeffseemann.test;` since you'll probably be using localhost for something else.
 Change the line `fastcgi_pass unix:/var/run/php5-fpm.sock;` to `fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;` or with whichever version of php you are using and the appropriate file path.
 ```sh
-sudo vim /etc/nginx/sites-enabled/jeff-website.com
+sudo vim /etc/nginx/sites-enabled/jeffseemann
 ```
-Update your hosts file to include your recent addition. Add the line `127.0.0.1 jeffwebsite.test`.
+Update your hosts file to include your recent addition. Add the line `127.0.0.1 jeffseemann.test`.
 ```sh
 sudo vim /etc/hosts
 ```
@@ -85,7 +85,7 @@ sudo chown -R $USER:www-data ~/jeffseemann.uconn.edu
 ```
 
 ### Install CMS dependencies
-After doing this, navigate to jeffwebsite.test/login.php in your browser to see the CMS.
+After doing this, navigate to jeffseemann.test/login.php in your browser to see the CMS.
 ```sh
 cd cms/
 composer install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1186,6 +1186,13 @@
         "qs": "6.5.1",
         "raw-body": "2.3.2",
         "type-is": "1.6.15"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        }
       }
     },
     "body-scroll-lock": {
@@ -3228,6 +3235,11 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         }
       }
     },
@@ -8048,9 +8060,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -8805,7 +8817,7 @@
         "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dotenv": "^5.0.1",
     "editorconfig": "^0.15.0",
     "lodash": "^4.17.5",
+    "qs": "^6.5.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
@@ -40,5 +41,13 @@
     "eslint-plugin-standard": "^3.0.1",
     "eslint-plugin-styled-components-config": "0.0.2",
     "sass-lint": "^1.12.1"
+  },
+  "proxy": {
+    "/api": {
+      "target": "http://jeffseemann.test"
+    },
+    "/storage": {
+      "target": "http://jeffseemann.test"
+    }
   }
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,7 +1,7 @@
 import url from 'url'
+import qs from 'qs'
 
-export const siteProtocol = process.env.REACT_APP_DIRECTUS_PROTOCOL
-export const siteHostname = process.env.REACT_APP_DIRECTUS_HOSTNAME
+export const endpoint = process.env.REACT_APP_DIRECTUS_ENDPOINT || '/'
 
 /**
  * Generic fetch to make api calls
@@ -26,7 +26,9 @@ export function apiFetchGeneric (protocol, hostname, pathname, query, ...args) {
  * @param {*} args - headers
  */
 export function apiFetch (pathname, query, ...args) {
-  return apiFetchGeneric(siteProtocol, siteHostname, pathname, query, ...args)
+  const path = url.resolve(endpoint, pathname + '?' + qs.stringify(query))
+  return fetch(path, ...args)
+    .then(response => response.json())
 }
 
 export function apiImageUrlGeneric (obj, imageurl) {
@@ -34,5 +36,5 @@ export function apiImageUrlGeneric (obj, imageurl) {
 }
 
 export function apiImageUrl (imageurl) {
-  return siteProtocol + '//' + siteHostname + imageurl
+  return url.resolve(endpoint, imageurl)
 }


### PR DESCRIPTION
I had to replace the call to url.format since it took protocol,
hostname, and port as separate arguments. An alternative that just joins
two paths makes envrionment setup a bit easier. (url.resolve)

So REACT_APP_DIRECTUS_PROTOCOL and REACT_APP_DIRECTUS_HOSTNAME are
deprecated in favor of REACT_APP_DIRECTUS_ENDPOINT, which is more
flexible.

These changes assume the site is setup at jeffseemann.test. I don't
believe there's a way at the moment to get package.json to use an
environment variable while proxying.