### PR TITLE
#9 Remove "Read More" if there is no abstract link

### DIFF
--- a/src/components/Publications/Publication.js
+++ b/src/components/Publications/Publication.js
@@ -29,9 +29,9 @@ class Publication extends Component {
     const showAbstract = this.state.show
       ? <div className="publication-abstract-text" style={black}>
         {abstract}
-        <div className="publication-abstract-readmore">
+        {url ? <div className="publication-abstract-readmore">
           <a className="publication-abstract-readmore-link" href={url} target="_blank">Read more!</a>
-        </div>
+        </div> : 'N/A'}
       </div>
       : <div></div>
 


### PR DESCRIPTION
Add conditional to only render "Read More" link when there is a url.